### PR TITLE
CI: add actionlint

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,23 @@
+name: Actionlint
+
+on:
+  pull_request:
+  push:
+    branches: main
+  # allow "manual" triggering from automatic PRs
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Taken from https://github.com/rhysd/actionlint/blob/v1.7.7/docs/usage.md#use-actionlint-on-github-actions
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }}
+        shell: bash

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -10,7 +10,7 @@ jobs:
   development:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v22
       - run: nix-build
       - run: nix-build -A tests


### PR DESCRIPTION
## Context

While working on https://github.com/tweag/nix-security-tracker/pull/1, I noticed there was no check on the quality of workflow files, so I'm proposing to add one.

## How to trust this PR

* [actionlint](https://github.com/rhysd/actionlint) is a well-established checker
* There was only one warning found by actionlint, which I fixed in the second commit: well done team 👏

I ran this pipeline manually on my fork, it looks like this (when only warning is not corrected: [this run](https://github.com/smelc/nix-security-tracker/actions/runs/14882894784/job/41794975378)):

![image](https://github.com/user-attachments/assets/144363c8-7330-4997-bf50-207da9a80fa9)
